### PR TITLE
[PR] Fetching token from socket assigns instead of `get_flash`

### DIFF
--- a/BUILDIT.md
+++ b/BUILDIT.md
@@ -183,8 +183,10 @@ end
 ```
 
 Your `app_controller.ex` should look like so.
-Take note we use `get_flash/2` 
-to use the `token` object
+We fetch the `token` object
+from the `:flash` socket assigns 
+that is made available to us
+by using the `:fetch_flash` plug.
 we've fetched earlier on the callback
 during the login process.
 
@@ -194,7 +196,7 @@ defmodule CalWeb.AppController do
 
   def app(conn, _params) do
 
-    conn = case get_flash(conn, :token) do
+    conn = case  Map.get(socket.assigns.flash, "token") do
       nil -> conn
       token -> assign(conn, :token, token)
     end
@@ -455,7 +457,7 @@ as shown below.
 
 
   defp get_token(conn) do
-    case get_flash(conn, :token) do
+    case Map.get(socket.assigns.flash, "token") do
       nil -> {:error, nil}
       token -> {:ok, token}
     end
@@ -569,7 +571,7 @@ defmodule CalWeb.AppLive do
 
 
   defp get_token(socket) do
-    case Phoenix.Controller.get_flash(socket, :token) do
+    case Map.get(socket.assigns.flash, "token") do
       nil -> {:error, nil}
       token -> {:ok, token}
     end
@@ -1710,7 +1712,7 @@ defmodule CalWeb.AppLive do
 
   # Get token from the flash session
   defp get_token(socket) do
-    case Phoenix.Controller.get_flash(socket, :token) do
+    case Map.get(socket.assigns.flash, "token") do
       nil -> {:error, nil}
       token -> {:ok, token}
     end

--- a/lib/cal_web/live/app_live.ex
+++ b/lib/cal_web/live/app_live.ex
@@ -175,7 +175,7 @@ defmodule CalWeb.AppLive do
 
   # Get token from the flash session
   defp get_token(socket) do
-    case Phoenix.Controller.get_flash(socket, :token) do
+    case Map.get(socket.assigns.flash, "token") do
       nil -> {:error, nil}
       token -> {:ok, token}
     end


### PR DESCRIPTION
closes #30 

Fixing the warning:

```
Warning: Phoenix.Controller.get_flash/2 is deprecated. get_flash/2 is deprecated.
```

